### PR TITLE
Bump @hapi/hoek and @hapi/joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -931,26 +931,26 @@
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
       "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
     },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
     "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/marker": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
-    },
-    "@hapi/marker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/topo": {
       "version": "3.1.2",
@@ -958,13 +958,6 @@
       "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
       "requires": {
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
-        }
       }
     },
     "@jest/console": {


### PR DESCRIPTION
Bumps [@hapi/hoek](https://github.com/hapijs/hoek) and [@hapi/joi](https://github.com/hapijs/joi). These dependencies needed to be updated together.

Updates `@hapi/hoek` from 6.2.4 to 8.5.1
- [Release notes](https://github.com/hapijs/hoek/releases)
- [Commits](https://github.com/hapijs/hoek/compare/v6.2.4...v8.5.1)

Updates `@hapi/joi` from 15.1.0 to 15.1.1
- [Release notes](https://github.com/hapijs/joi/releases)
- [Commits](https://github.com/hapijs/joi/compare/v15.1.0...v15.1.1)

---
updated-dependencies:
- dependency-name: "@hapi/hoek" dependency-type: indirect
- dependency-name: "@hapi/joi" dependency-type: indirect ...